### PR TITLE
Windows/MSVC compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,10 @@ To install with references to the source code where it is downloaded (so that
 changes in the sourcecode are reflected immediately):
 
 $ pip install -e <DIR>[cuda] --user
+
+For windows installation install all required software with pip or conda and run
+following in the kde-directory while in your prefered python environment
+
+$ pip install ".[cuda]"
+
+

--- a/kde/kde.c
+++ b/kde/kde.c
@@ -27,7 +27,14 @@
 
 #include <Python.h>
 #include <math.h>
+
+#ifdef _MSC_VER
+#include <winsock.h>
+
+#else
 #include <time.h>
+
+#endif
 
 #include <stdio.h>
 #define _USE_MATH_DEFINES

--- a/setup.py
+++ b/setup.py
@@ -5,13 +5,15 @@ from distutils.core import setup, Extension
 
 
 if __name__ == "__main__":
+    if(platform.system()=='Windows'):
+        extra_compile_args=['-Wall', '-O2']
+    else:
+        extra_compile_args=['-Wall', '-O3', '-fPIC', '-Werror']
+
     ckde = Extension(
         name='kde.kde',
         sources=['kde/kde.c'],
-        if(platform.system()=='Windows'):
-            extra_compile_args=['-Wall', '-O2']
-        else:
-            extra_compile_args=['-Wall', '-O3', '-fPIC', '-Werror']
+        extra_compile_args=extra_compile_args
     )
 
     setup(

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-
+import platform
 from distutils.core import setup, Extension
 
 
@@ -8,7 +8,10 @@ if __name__ == "__main__":
     ckde = Extension(
         name='kde.kde',
         sources=['kde/kde.c'],
-        extra_compile_args=['-Wall', '-O3', '-fPIC', '-Werror']
+        if platform.system()=='Windows':
+            extra_compile_args=['-Wall', '-O2']
+        else:
+            extra_compile_args=['-Wall', '-O3', '-fPIC', '-Werror']
     )
 
     setup(

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ if __name__ == "__main__":
     ckde = Extension(
         name='kde.kde',
         sources=['kde/kde.c'],
-        if platform.system()=='Windows':
+        if(platform.system()=='Windows'):
             extra_compile_args=['-Wall', '-O2']
         else:
             extra_compile_args=['-Wall', '-O3', '-fPIC', '-Werror']


### PR DESCRIPTION
Added preliminary code for  compatibility in Windows with MS Visual Code C compiler.

setup.py checks if system is windows and changes the compilation flags to those used in Visual Code (different optimization level, no need for PIC and no Werror).

It would be better if this would be handled with checking if the compiler is MSVC, but there is no shorthand for it.

In the c-code I added check if the compiler is MSVC and changed the time-library header for correct one for MSVC if the compiler is MSVC.

Code is not tested on linux, but it should work.........